### PR TITLE
Добавил postgres, docker, docker-compose

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+venv
+.git
+.idea
+.vscode
+.env
+db.sqlite3
+db.sqlite3.bak

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11.4
+
+RUN pip3 install --upgrade pip
+
+WORKDIR /app
+
+RUN pip install gunicorn==20.1.0
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt --no-cache-dir
+
+COPY . .
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "forecast.wsgi"]

--- a/backend/api/management/commands/load_data.py
+++ b/backend/api/management/commands/load_data.py
@@ -1,10 +1,9 @@
 from csv import DictReader
 
 from categories.models import Category, Group, Product, Subcategory
-from django.conf import settings
 from django.core.management.base import BaseCommand
 
-data_dir = settings.BASE_DIR/'initial_data'
+data_dir = 'initial_data'
 
 
 csv_files = [
@@ -49,7 +48,7 @@ class Command(BaseCommand):
         )
 
     def csv_loader(self, cf):
-        csv_file = f'{data_dir}\\{cf["filename"]}'
+        csv_file = f'{data_dir}/{cf["filename"]}'
         with open(csv_file, encoding='utf-8', newline='') as csvfile:
             reader = DictReader(csvfile, fieldnames=cf['fieldnames'])
             print(f'Загрузка в таблицу модели {cf["model"].__name__}')

--- a/backend/forecast/settings.py
+++ b/backend/forecast/settings.py
@@ -1,4 +1,9 @@
+import os
 from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -80,10 +85,28 @@ DJOSER = {
 WSGI_APPLICATION = 'forecast.wsgi.application'
 
 
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.sqlite3', # без докера
+#         'NAME': BASE_DIR / 'db.sqlite3',
+#     }
+# }
+
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.sqlite3', # для пробного докера на sqlite
+#         'NAME': '/data/db.sqlite3',
+#     }
+# }
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('POSTGRES_DB', 'django'),
+        'USER': os.getenv('POSTGRES_USER', 'django'),
+        'PASSWORD': os.getenv('POSTGRES_PASSWORD', ''),
+        'HOST': os.getenv('DB_HOST', ''),
+        'PORT': os.getenv('DB_PORT', 5432)
     }
 }
 
@@ -113,6 +136,9 @@ USE_I18N = True
 USE_TZ = True
 
 
-STATIC_URL = 'static/'
+STATIC_URL = '/static/'
+STATIC_ROOT = BASE_DIR / 'collected_static'
+MEDIA_URL = '/media/'
+MEDIA_ROOT = '/media'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,8 +11,10 @@ djangorestframework-simplejwt==5.3.0
 djoser==2.2.0
 idna==3.4
 oauthlib==3.2.2
+psycopg2-binary==2.9.7
 pycparser==2.21
 PyJWT==2.8.0
+python-dotenv==1.0.0
 python3-openid==3.2.0
 pytz==2023.3.post1
 requests==2.31.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+
+volumes:
+  pg_data:
+  static:
+
+services:
+  db:
+    image: postgres:13.10
+    env_file: .env
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+  backend:
+    build: ./backend/
+    env_file: .env
+    depends_on:
+      - db
+    volumes:
+      - static:/backend_static
+  gateway:
+    build: ./gateway/
+    volumes:
+      - static:/staticfiles/
+    ports:
+      - 8000:80

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:1.22.1
+COPY nginx.conf /etc/nginx/templates/default.conf.template

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -1,0 +1,25 @@
+server {
+  listen 80;
+  index index.html;
+  server_tokens off;
+
+  location /api/v1/ {
+    proxy_set_header Host $http_host;
+    proxy_pass http://backend:8000/api/v1/;
+  }
+  location /admin/ {
+    proxy_set_header Host $http_host;
+    proxy_pass http://backend:8000/admin/;
+  }
+
+  location /media/ {
+    proxy_set_header Host $http_host;
+    alias /media/;
+  }
+
+  location / {
+    proxy_set_header Host $http_host;
+    alias /staticfiles/;
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
Добавил postgres, docker. В settings настройки базы sqlite не стал удалять, а закомментил, чтобы можно было оперативно на нее переключится для каких-то тестов. Должно все собираться и работать в контейнерах. Для этого в терминале из директории проекта hackaton-lenta запустить
`docker compose up --build`
после этого собрать статику Django:
`docker compose exec backend python manage.py collectstatic`
скопировать ее на volume static
`docker compose exec backend cp -r collected_static/. ../backend_static/static/`
затем сделать миграции:
`docker compose exec backend python manage.py migrate`
и можно создать суперпользователя
`winpty docker compose exec backend python manage.py createsuperuser`  - у меня через winpty, т.к. на винде работаю
Для загрузки данных в postgres в контейнере:
`docker compose exec backend python manage.py load_data`