### PR TITLE
Backend feat sales data to file

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r requirements.txt --no-cache-dir
 
 COPY . .
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "forecast.wsgi"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--timeout", "7200", "forecast.wsgi"]

--- a/backend/forecast/settings.py
+++ b/backend/forecast/settings.py
@@ -139,6 +139,7 @@ USE_I18N = True
 
 USE_TZ = True
 
+TIMEOUT = 7200
 
 STATIC_URL = '/static/'
 STATIC_ROOT = BASE_DIR / 'collected_static'

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -3,6 +3,8 @@ server {
   index index.html;
   server_tokens off;
 
+  proxy_read_timeout 7200;
+  proxy_send_timeout 7200;
   location /api/v1/ {
     proxy_set_header Host $http_host;
     proxy_pass http://backend:8000/api/v1/;


### PR DESCRIPTION
Добавил выгрузку в файл данных о продажах. Выгрузка начинается при get запросе типа: `http://127.0.0.1:8000/api/v1/sales/sales_data_to_file?file_name=<имя файла>` При этом происходит выгрузка из БД данных о всех продажах в файл <имя файла>.csv, который сохраняется в volume бэкенда (/backend_static/). Асинхронка пока не реализована, поэтому добавил настройки таймаутов, чтобы во время ожидания выгрузки не происходило ошибки по времени ожидания ответа. У меня выгрузка занимала около получаса.